### PR TITLE
Replacing Selectors with proper BaseSelector class

### DIFF
--- a/force-app/main/default/classes/AchievementReachedEventsManager.cls
+++ b/force-app/main/default/classes/AchievementReachedEventsManager.cls
@@ -2,12 +2,12 @@ public with sharing class AchievementReachedEventsManager {
 
 	Map<Id, UserMeasurement__c> userMeasurementsByIdMap = new Map<Id, UserMeasurement__c>();
 	Map<Id, List<Achievement__c>> achievementByMeasurementIdMap = new Map<Id, List<Achievement__c>>();
-	Map<Id, Map<String, ReachedAchievement__c>> reachedAchievementsByAchievementIdMap = new Map<Id, Map<String, ReachedAchievement__c>>();
+	Map<String, ReachedAchievement__c> existingReachedAchievementsByKey = new Map<String, ReachedAchievement__c>();
 
 	public AchievementReachedEventsManager(Map<Id, UserMeasurement__c> userMeasurementsByIdMap) {
 		this.userMeasurementsByIdMap = userMeasurementsByIdMap;
 		this.populateAchievementsByMeasurementIdMap();
-		this.populateReachedAchievementsByAchievementIdMap();
+		this.populateExistingReachedAchievementsByKey();
 	}
 
 	public List<Database.SaveResult> fireEvents() {
@@ -40,25 +40,25 @@ public with sharing class AchievementReachedEventsManager {
 			measurementIds.add(userMeasurement.Measurement__c);
 		}
 
-		List<Measurement__c> measurements = MeasurementSelector.getByIds(measurementIds);
-		for (Measurement__c measurement : measurements) {
-			List<Achievement__c> achievements = measurement.Achievements__r;
-			if (achievements != null && !achievements.isEmpty()) {
-				achievementByMeasurementIdMap.put(measurement.Id, achievements);
+		List<Achievement__c> achievements = AchievementSelector.getInstance().getByFieldValue('Measurement__c', 'IN', measurementIds);
+		for (Achievement__c achievement : achievements) {
+			if (!achievementByMeasurementIdMap.containsKey(achievement.Measurement__c)) {
+				achievementByMeasurementIdMap.put(achievement.Measurement__c, new List<Achievement__c>());
 			}
+			achievementByMeasurementIdMap.get(achievement.Measurement__c).add(achievement);
 		}
 	}
 
-	private void populateReachedAchievementsByAchievementIdMap() {
-		Set<Id> achievementIds = new Set<Id>();
-		for (Id key : achievementByMeasurementIdMap.keySet()) {
-			List<Achievement__c> achievements = achievementByMeasurementIdMap.get(key);
-			for (Achievement__c achievement : achievements) {
-				achievementIds.add(achievement.Id);
-			}
+	private void populateExistingReachedAchievementsByKey() {
+		Set<Id> userIds = new Set<Id>();
+		for(UserMeasurement__c userMeasurement : userMeasurementsByIdMap.values()) {
+			userIds.add(userMeasurement.User__c);
 		}
-
-		reachedAchievementsByAchievementIdMap = AchievementSelector.getReachedAchievementsByAchievementId(achievementIds);
+		
+		List<ReachedAchievement__c> reachedAchievements = ReachedAchievementSelector.getInstance().getByFieldValue('User__c', 'IN', userIds);
+		for (ReachedAchievement__c reachedAchievement : reachedAchievements) {
+			existingReachedAchievementsByKey.put(reachedAchievement.Key__c, reachedAchievement);
+		}
 	}
 	
 	private Boolean validate() {
@@ -73,9 +73,9 @@ public with sharing class AchievementReachedEventsManager {
 
 	private Boolean achievementReachedExists(Id userId, Id achievementId) {
 		Boolean result = false;
-		String key = userId + '-' + achievementId;
+		String key = UniqueKeyFormatter.generateUniqueKey(userId, achievementId);
 
-		if (reachedAchievementsByAchievementIdMap.get(achievementId)?.get(key) != null) {
+		if (existingReachedAchievementsByKey.containsKey(key)) {
 			result = true;
 		}
 

--- a/force-app/main/default/classes/AchievementReachedTriggerHandler.cls
+++ b/force-app/main/default/classes/AchievementReachedTriggerHandler.cls
@@ -2,7 +2,8 @@ public with sharing class AchievementReachedTriggerHandler {
 	Logger logger = new Logger();
 	List<AchievementReached__e> eventsToProcess = new List<AchievementReached__e>();
 	Map<Id, User> existingUsersMap = new Map<Id, User>();
-	Map<Id, Map<String, ReachedAchievement__c>> existingReachedAchievementsMap = new Map<Id, Map<String, ReachedAchievement__c>>();
+	Map<Id, Achievement__c> existingAchievementsMap = new Map<Id, Achievement__c>();
+	Map<String, ReachedAchievement__c> existingReachedAchievementsByKeyMap = new Map<String, ReachedAchievement__c>();
 	Map<String, ReachedAchievement__c> reachedAchievementsToInsert = new Map<String, ReachedAchievement__c>();
 
 	public AchievementReachedTriggerHandler(List<AchievementReached__e> events) {
@@ -13,14 +14,21 @@ public with sharing class AchievementReachedTriggerHandler {
 	private void init(List<AchievementReached__e> events) {
 		Set<Id> achievementIds = new Set<Id>();
 		Set<Id> userIds = new Set<Id>();
+		Set<String> achievementReachedKeys = new Set<String>();
 
 		for (AchievementReached__e event : events) {
 			achievementIds.add(event.AchievementId__c);
 			userIds.add(event.userId__c);
+			achievementReachedKeys.add(UniqueKeyFormatter.generateUniqueKey(event.userId__c, event.AchievementId__c));
 		}
 
-		existingUsersMap = new Map<Id, User> (UserSelector.getByIds(userIds));
-		existingReachedAchievementsMap = AchievementSelector.getReachedAchievementsByAchievementId(achievementIds);
+		existingUsersMap = new Map<Id, User> ((List<User>) UserSelector.getInstance().getByIds(userIds));
+		existingAchievementsMap = new Map<Id, Achievement__c> ((List<Achievement__c>) AchievementSelector.getInstance().getByIds(achievementIds));
+		
+		List<ReachedAchievement__c> existingReachedAchievements = (List<ReachedAchievement__c>) ReachedAchievementSelector.getInstance().getByFieldValue('Key__c', 'IN', achievementReachedKeys);
+		for (ReachedAchievement__c existingReachedAchievement : existingReachedAchievements) {
+			existingReachedAchievementsByKeyMap.put(existingReachedAchievement.Key__c, existingReachedAchievement);
+		}
 	}
 
 	public void processEvents() {
@@ -30,9 +38,8 @@ public with sharing class AchievementReachedTriggerHandler {
 					continue;
 				}
 
-				String userAchievementKey = event.UserId__c + '-' + event.AchievementId__c;
-				Map<String, ReachedAchievement__c> reachedAchievements = existingReachedAchievementsMap.get(event.AchievementId__c);
-				if (reachedAchievements.isEmpty() || !reachedAchievements.containsKey(userAchievementKey)) {
+				String userAchievementKey = UniqueKeyFormatter.generateUniqueKey(event.userId__c, event.AchievementId__c);
+				if (!existingReachedAchievementsByKeyMap.containsKey(userAchievementKey)) {
 					ReachedAchievement__c reachedAchievement = new ReachedAchievement__c();
 					reachedAchievement.User__c = event.UserId__c;
 					reachedAchievement.Achievement__c = event.AchievementId__c;
@@ -84,7 +91,7 @@ public with sharing class AchievementReachedTriggerHandler {
 	}
 
 	private Boolean isValidAchievementId(Id achievementId) {
-		return existingReachedAchievementsMap.containsKey(achievementId);
+		return existingAchievementsMap.containsKey(achievementId);
 	}
 
 	public static void onAfterInsert(List<AchievementReached__e> events) {

--- a/force-app/main/default/classes/AchievementSelector.cls
+++ b/force-app/main/default/classes/AchievementSelector.cls
@@ -1,48 +1,14 @@
-public with sharing class AchievementSelector {
-	private static final String FIELDS_LIST = 
-		'Id, ' +
-		'Name, ' +
-		'Description__c, ' +
-		'Enabled__c, ' +
-		'Goal__c, ' +
-		'Score__c, ' +
-		'UITitle__c, ' +
-		'UIDescription__c, ' +
-		'(SELECT Id, Key__c, User__c, Achievement__c FROM ReachedAchievements__r)';
+public with sharing class AchievementSelector extends BaseSelector {
 
-	public static List<Achievement__c> getByIds(Set<Id> ids) {
-		if (ids.isEmpty()) {
-			return new List<Achievement__c>();
-		}
-
-		Map<String, Object> binds = new Map<String, Object> { 'ids' => ids };
-		return Database.queryWithBinds('SELECT ' + FIELDS_LIST + ' FROM Achievement__c WHERE Id IN :ids', binds, System.AccessLevel.SYSTEM_MODE);
+	public static AchievementSelector getInstance() {
+		return new AchievementSelector();
 	}
 
-	public static Map<Id, Map<String, ReachedAchievement__c>> getReachedAchievementsByAchievementId(Set<Id> ids) {
-		Map<Id, Map<String, ReachedAchievement__c>> reachedAchievementByAchievementIdsMap = new Map<Id, Map<String, ReachedAchievement__c>>();
-
-		if (ids.isEmpty()) {
-			return reachedAchievementByAchievementIdsMap;
-		}
-
-		Map<String, Object> binds = new Map<String, Object> { 'ids' => ids };
-		List<Achievement__c> achievements = Database.queryWithBinds('SELECT ' + FIELDS_LIST + ' FROM Achievement__c WHERE Id IN :ids', binds, System.AccessLevel.SYSTEM_MODE);
-
-		for (Achievement__c achievement : achievements) {
-			Map<String, ReachedAchievement__c> reachedAchievementsByIdMap = new Map<String, ReachedAchievement__c>();
-			List<ReachedAchievement__c> reachedAchievements = achievement.ReachedAchievements__r;
-			for (ReachedAchievement__c reachedAchievement : reachedAchievements) {
-				reachedAchievementsByIdMap.put(reachedAchievement.Key__c, reachedAchievement);
-			}
-
-			reachedAchievementByAchievementIdsMap.put(achievement.Id, reachedAchievementsByIdMap);
-		}
-
-		return reachedAchievementByAchievementIdsMap;
+	public override String sObjectApiName() {
+		return 'Achievement__c';
 	}
 
-	public static Integer getTotalCount() {
-		return Database.countQuery('SELECT COUNT() FROM Achievement__c', System.AccessLevel.SYSTEM_MODE);
+	public override Set<String> fieldApiNames() {
+		return new Set<String> {'Id', 'Name', 'Description__c', 'Enabled__c', 'Goal__c', 'Score__c', 'UITitle__c', 'UIDescription__c', 'Measurement__c'};
 	}
 }

--- a/force-app/main/default/classes/AchievementSelectorTest.cls
+++ b/force-app/main/default/classes/AchievementSelectorTest.cls
@@ -1,119 +1,32 @@
-@IsTest
+@IsTest(isParallel=true)
 private class AchievementSelectorTest {
 
 	@IsTest
-	private static void getByIds_recordWithIdExists_recordsReturned(){
+	private static void sObjectApiName_sObjectNameReturned_nameIsValidated() {
 		// Given
-		Measurement__c measurement = TestDataFactory.createMeasurement('Measurement');
-		Achievement__c achievement1 = TestDataFactory.createAchievement('Found', measurement.Id);
-		Achievement__c achievement2 = TestDataFactory.createAchievement('Not found', measurement.Id);
-
-		// When 
-		Test.startTest();
-		List<Achievement__c> result = AchievementSelector.getByIds(new Set<Id>{ achievement1.Id });
-		Map<Id,Achievement__c> resultMap = new Map<Id,Achievement__c>(result);
-		Test.stopTest();
-
-		// Then
-		System.assertEquals(1, result.size(), 'Record is expected to be found');
-		System.assert(resultMap.containsKey(achievement1.Id), 'Map is expected to have a specific achievement');
-		System.assert(!resultMap.containsKey(achievement2.Id), 'Map is not expected to have a specific achievement');
-	}
-
-	@IsTest
-	private static void getByIds_emptyIdsSet_emptyListReturned(){
-		// Given
-		Set<Id> ids = new Set<Id>();
-
-		// When 
-		Test.startTest();
-		List<Achievement__c> result = AchievementSelector.getByIds(ids);
-		Test.stopTest();
-
-		// Then
-		System.assertNotEquals(null, result, 'Empty list is expected');
-		System.assertEquals(0, result.size(), 'Empty list is expected');
-	}
-
-	@IsTest
-	private static void getByIds_noRecordsFound_emptyListReturned(){
-		// Given
-		Measurement__c measurement = TestDataFactory.createMeasurement('Measurement');
-		Achievement__c achievement = TestDataFactory.createAchievement('REMOVED', measurement.Id);
-		Id achievementId = achievement.Id;
-		delete new List<Achievement__c> { achievement };
-
-		// When 
-		Test.startTest();
-		List<Achievement__c> result = AchievementSelector.getByIds(new Set<Id> { achievementId });
-		Test.stopTest();
-
-		// Then
-		System.assertNotEquals(null, result, 'Empty list is expected');
-		System.assertEquals(0, result.size(), 'Empty list is expected');
-	}
-
-	@IsTest
-	private static void getReachedAchievementsByAchievementId_reachedAchievementsExist_mapReturned() {
-		// Given
-		Id profileId = UserInfo.getProfileId();
-		User user1 = TestDataFactory.createUser(profileId, 'user1');
-		User user2 = TestDataFactory.createUser(profileId, 'user2');
-		Measurement__c measurement = TestDataFactory.createMeasurement('Measurement');
-		Achievement__c achievement1 = TestDataFactory.createAchievement('Achievement1', measurement.Id);
-		Achievement__c achievement2 = TestDataFactory.createAchievement('Achievement2', measurement.Id);
-		ReachedAchievement__c reached1 = TestDataFactory.createReachedAchievement(user1.Id, achievement1.Id);
-		ReachedAchievement__c reached2 = TestDataFactory.createReachedAchievement(user1.Id, achievement2.Id);
-		ReachedAchievement__c reached3 = TestDataFactory.createReachedAchievement(user2.Id, achievement1.Id);
-
+		AchievementSelector selector = AchievementSelector.getInstance();
+		
 		// When
 		Test.startTest();
-		Map<Id, Map<String, ReachedAchievement__c>> result = AchievementSelector.getReachedAchievementsByAchievementId(new Set<Id> { achievement1.Id, achievement2.Id });
+		String result = selector.sObjectApiName();
 		Test.stopTest();
 
-		// Then
-		System.assertNotEquals(null, result.isEmpty(), 'result expected to be populated');
-		System.assertNotEquals(0, result.size(), 'result expected to be populated');
-		System.assert(result.containsKey(achievement1.Id));
-		Map<String, ReachedAchievement__c> achievement1Result = result.get(achievement1.Id);
-		System.assert(achievement1Result.containsKey(user1.Id + '-' + achievement1.Id), 'Expected to get AchievementReached by key');
-		System.assert(achievement1Result.containsKey(user2.Id + '-' + achievement1.Id), 'Expected to get AchievementReached by key');
-
-		System.assert(result.containsKey(achievement2.Id));
-		Map<String, ReachedAchievement__c> achievement2Result = result.get(achievement2.Id);
-		System.assert(achievement2Result.containsKey(user1.Id + '-' + achievement2.Id), 'Expected to get AchievementReached by key');
-		
+		// Then 
+		system.assertEquals('Achievement__c', result, 'Achievement__c sObject ApiName is expected');
 	}
 
 	@IsTest
-	private static void getReachedAchievementsByAchievementId_emptyListOfIds_emptyMapReturned() {
+	private static void fieldApiNames_sObjectNameReturned_fieldSetIsValidated() {
 		// Given
-
+		AchievementSelector selector = AchievementSelector.getInstance();
+		
 		// When
 		Test.startTest();
-		Map<Id, Map<String, ReachedAchievement__c>> result = AchievementSelector.getReachedAchievementsByAchievementId(new Set<Id>());
+		Set<String> result = selector.fieldApiNames();
 		Test.stopTest();
 
-		// Then
-		System.assertNotEquals(null, result.isEmpty(), 'result expected to be not null');
-		System.assert(result.isEmpty(), 'result is expected to be empty');
-		
-	}
-
-	@IsTest
-	private static void getTotalCount_recordsExists_countReturned(){
-		// Given
-		Measurement__c measurement = TestDataFactory.createMeasurement('Measurement');
-		Achievement__c achievement1 = TestDataFactory.createAchievement('Ach1', measurement.Id);
-		Achievement__c achievement2 = TestDataFactory.createAchievement('Ach2', measurement.Id);
-		Achievement__c achievement3 = TestDataFactory.createAchievement('Ach3', measurement.Id);
-
-		// When 
-		Test.startTest();
-		Integer result = AchievementSelector.getTotalCount();
-		Test.stopTest();
-
-		// Then
-		System.assertEquals(3, result, ' 3 records are expected to be returned');
+		// Then 
+		Set<String> expectedSet = new Set<String> {'Id', 'Name', 'Description__c', 'Enabled__c', 'Goal__c', 'Score__c', 'UITitle__c', 'UIDescription__c', 'Measurement__c'};
+		system.assertEquals(expectedSet, result, 'A specific field set is expected');
 	}
 }

--- a/force-app/main/default/classes/BaseGameForceTriggerHandler.cls
+++ b/force-app/main/default/classes/BaseGameForceTriggerHandler.cls
@@ -10,10 +10,9 @@ public virtual class BaseGameForceTriggerHandler {
 			measurementIdsByUniqueIds.put(measurementUniqueId, null);
 		}
 
-		Map<String, Measurement__c> measurementsByUniqueIdMap = MeasurementSelector.getByUniqueIds(Constants.MEASUREMENT_UNIQUE_IDS);
-		
-		for (String uniqueId : measurementsByUniqueIdMap.keySet()) {
-			measurementIdsByUniqueIds.put(uniqueId, measurementsByUniqueIdMap.get(uniqueId).Id);
+		List<Measurement__c> measurements = (List<Measurement__c>) MeasurementSelector.getInstance().getByFieldValue('UniqueIdentifier__c', 'IN', Constants.MEASUREMENT_UNIQUE_IDS);
+		for (Measurement__c measurement : measurements) {
+			measurementIdsByUniqueIds.put(measurement.UniqueIdentifier__c, measurement.Id);
 		}
 	}
 

--- a/force-app/main/default/classes/BaseSelector.cls
+++ b/force-app/main/default/classes/BaseSelector.cls
@@ -1,0 +1,29 @@
+public abstract class BaseSelector {
+
+	public abstract String sObjectApiName();
+	public abstract Set<String> fieldApiNames();
+
+	public List<sObject> getByFieldValue(String filterFieldApiName, String compOperator, Object values) {
+		List<sObject> result = new List<sObject>(); 
+		if (values != null) {
+			Map<String, Object> binds = new Map<String, Object> { 'values' => values };
+			result = Database.queryWithBinds(
+				'SELECT ' + queryFieldApiNamesStr() + ' FROM ' + sObjectApiName() + ' ' +
+				'WHERE ' + filterFieldApiName + ' ' + compOperator + ' :values', 
+				binds, System.AccessLevel.SYSTEM_MODE);
+		}
+		return result; 
+	}
+
+	public List<sObject> getAll() {
+		return Database.query('SELECT ' + queryFieldApiNamesStr() + ' FROM ' + sObjectApiName(), System.AccessLevel.SYSTEM_MODE);
+	}
+
+	public List<sObject> getByIds(Set<Id> ids) {
+		return this.getByFieldValue('Id', 'IN', (Object) ids); 
+	}
+
+	private String queryFieldApiNamesStr() {
+		return String.join(new List<String>(fieldApiNames()), ',');
+	}
+}

--- a/force-app/main/default/classes/BaseSelector.cls-meta.xml
+++ b/force-app/main/default/classes/BaseSelector.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>57.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/FeedItemTriggerHandlerTest.cls
+++ b/force-app/main/default/classes/FeedItemTriggerHandlerTest.cls
@@ -22,7 +22,7 @@ private class FeedItemTriggerHandlerTest {
 	}
 
 	@IsTest
-	private static void onAfterUpdate_201RecordsConverteed_userMeasurementsCreated(){
+	private static void onAfterUpdate_201RecordsConverted_userMeasurementsCreated(){
 		// Given
 		Measurement__c measurement = TestDataFactory.createMeasurement(Constants.CHATTER_POSTS_COUNTER_ID);
 		Achievement__c achievement = TestDataFactory.createAchievement('Achievement', measurement.Id);

--- a/force-app/main/default/classes/LeaderboardController.cls
+++ b/force-app/main/default/classes/LeaderboardController.cls
@@ -1,10 +1,9 @@
 public with sharing class LeaderboardController {
-	
 	@AuraEnabled(cacheable=true)
 	public static Map<String, Object> getTotalNumberOfAchievements() {
 		Integer result;
 		try {
-			result = AchievementSelector.getTotalCount();
+			result = AchievementSelector.getInstance().getAll().size();
 		} catch (Exception e) {
 			Logger.saveSingleLog('Unexpected exception caught in UserAchievementsController. ' + e.getMessage() + '. ' + e.getStackTraceString());
 			return ControllerResponse.error('Unable to get total achievements count');
@@ -30,8 +29,8 @@ public with sharing class LeaderboardController {
 	private static Map<Id, UserInfoWrapper> getUserInfoById(Set<Id> userIds) {
 		Map<Id, UserInfoWrapper> result = new Map<Id, UserInfoWrapper>();
 
-		List<User> users = UserSelector.getByIds(userIds);
-		Map<Id, AggregateResult> reachedAchievementsData = ReachedAchievementSelector.getGroupedScoreAndCountByUser(userIds);
+		List<User> users = UserSelector.getInstance().getByIds(userIds);
+		Map<Id, AggregateResult> reachedAchievementsData = UserRatingsHelper.getTotalScoreAndCountByUser(userIds);
 		for (User user : users) {
 			AggregateResult userAchievementsData = reachedAchievementsData.get(user.Id);
 			UserInfoWrapper userInfoWrapper = new UserInfoWrapper();

--- a/force-app/main/default/classes/MeasurementSelector.cls
+++ b/force-app/main/default/classes/MeasurementSelector.cls
@@ -1,33 +1,14 @@
-public with sharing class MeasurementSelector {
+public with sharing class MeasurementSelector extends BaseSelector {
 
-	private static final String FIELDS_LIST = 
-		'Id, ' +
-		'Name, ' +
-		'UniqueIdentifier__c, ' +
-		'Description__c, ' +
-		'(SELECT Id, Goal__c FROM Achievements__r)';
-
-	public static List<Measurement__c> getByIds(Set<Id> ids) {
-		if (ids.isEmpty()) {
-			return new List<Measurement__c>();
-		}
-
-		Map<String, Object> binds = new Map<String, Object> { 'ids' => ids };
-		return Database.queryWithBinds('SELECT ' + FIELDS_LIST + ' FROM Measurement__c WHERE Id IN :ids', binds, System.AccessLevel.SYSTEM_MODE);
+	public static MeasurementSelector getInstance() {
+		return new MeasurementSelector();
 	}
 
-	public static Map<String, Measurement__c> getByUniqueIds(Set<String> uniqueIds) {
-		Map<String, Measurement__c> result = new Map<String, Measurement__c>();
-		
-		if (uniqueIds.isEmpty()) {
-			return result;
-		}
+	public override String sObjectApiName() {
+		return 'Measurement__c';
+	}
 
-		Map<String, Object> binds = new Map<String, Object> { 'ids' => uniqueIds };
-		List<Measurement__c> measurements = Database.queryWithBinds('SELECT ' + FIELDS_LIST + ' FROM Measurement__c WHERE UniqueIdentifier__c IN :ids', binds, System.AccessLevel.SYSTEM_MODE);
-		for (Measurement__c measurement : measurements) {
-			result.put(measurement.UniqueIdentifier__c, measurement);
-		}
-		return result;
+	public override Set<String> fieldApiNames() {
+		return new Set<String> {'Id', 'Name', 'UniqueIdentifier__c', 'Description__c'};
 	}
 }

--- a/force-app/main/default/classes/MeasurementSelectorTest.cls
+++ b/force-app/main/default/classes/MeasurementSelectorTest.cls
@@ -1,99 +1,31 @@
 @IsTest(isParallel=true)
 private class MeasurementSelectorTest {
 	@IsTest
-	private static void getByIds_recordWithIdExists_recordsReturned(){
+	private static void sObjectApiName_sObjectNameReturned_nameIsValidated() {
 		// Given
-		Measurement__c measurement1 = TestDataFactory.createMeasurement('Found');
-		Measurement__c measurement2 = TestDataFactory.createMeasurement('Not found');
-
-		// When 
+		MeasurementSelector selector = MeasurementSelector.getInstance();
+		
+		// When
 		Test.startTest();
-		List<Measurement__c> result = MeasurementSelector.getByIds(new Set<Id>{ measurement1.Id });
-		Map<Id,Measurement__c> resultMap = new Map<Id,Measurement__c>(result);
+		String result = selector.sObjectApiName();
 		Test.stopTest();
 
-		// Then
-		System.assertEquals(1, result.size(), 'Record is expected to be found');
-		System.assert(resultMap.containsKey(measurement1.Id), 'Map is expected to have a specific measurement');
-		System.assert(!resultMap.containsKey(measurement2.Id), 'Map is not expected to have a specific measurement');
+		// Then 
+		system.assertEquals('Measurement__c', result, 'Measurement__c sObject ApiName is expected');
 	}
 
 	@IsTest
-	private static void getByIds_emptyIdsSet_emptyListReturned(){
+	private static void fieldApiNames_sObjectNameReturned_fieldSetIsValidated() {
 		// Given
-		Set<Id> ids = new Set<Id>();
-
-		// When 
+		MeasurementSelector selector = MeasurementSelector.getInstance();
+		
+		// When
 		Test.startTest();
-		List<Measurement__c> result = MeasurementSelector.getByIds(ids);
+		Set<String> result = selector.fieldApiNames();
 		Test.stopTest();
 
-		// Then
-		System.assertNotEquals(null, result, 'Empty list is expected');
-		System.assertEquals(0, result.size(), 'Empty list is expected');
-	}
-
-	@IsTest
-	private static void getByIds_noRecordsFound_emptyListReturned(){
-		// Given
-		Measurement__c measurement = TestDataFactory.createMeasurement('REMOVED');
-		Id measurementId = measurement.Id;
-		delete new List<Measurement__c> { measurement };
-
-		// When 
-		Test.startTest();
-		List<Measurement__c> result = MeasurementSelector.getByIds(new Set<Id> { measurementId });
-		Test.stopTest();
-
-		// Then
-		System.assertNotEquals(null, result, 'Empty list is expected');
-		System.assertEquals(0, result.size(), 'Empty list is expected');
-	}
-
-	@IsTest
-	private static void getByUniqueIds_recordWithUniqueIdExists_recordsReturned(){
-		// Given
-		Measurement__c measurement1 = TestDataFactory.createMeasurement('Found');
-		Measurement__c measurement2 = TestDataFactory.createMeasurement('Not found');
-
-		// When 
-		Test.startTest();
-		Map<String, Measurement__c> result = MeasurementSelector.getByUniqueIds(new Set<String>{ 'Found' });
-		Test.stopTest();
-
-		// Then
-		System.assertEquals(1, result.size(), 'Record is expected to be found');
-		System.assert(result.containsKey('Found'), 'Map is expected to have a specific measurement');
-		System.assert(!result.containsKey('Not found'), 'Map is not expected to have a specific measurement');
-	}
-
-	@IsTest
-	private static void getByUniqueIds_emptyIdsSet_emptyListReturned(){
-		// Given
-		Set<String> uniqueIds = new Set<String>();
-
-		// When 
-		Test.startTest();
-		Map<String, Measurement__c> result = MeasurementSelector.getByUniqueIds(uniqueIds);
-		Test.stopTest();
-
-		// Then
-		System.assertNotEquals(null, result, 'Empty map is expected');
-		System.assertEquals(0, result.size(), 'Empty map is expected');
-	}
-
-	@IsTest
-	private static void getByUniqueIds_noRecordsFound_emptyListReturned(){
-		// Given
-		Set<String> uniqueIds = new Set<String>{'Non existing id'};
-
-		// When 
-		Test.startTest();
-		Map<String, Measurement__c> result = MeasurementSelector.getByUniqueIds(uniqueIds);
-		Test.stopTest();
-
-		// Then
-		System.assertNotEquals(null, result, 'Empty list is expected');
-		System.assertEquals(0, result.size(), 'Empty list is expected');
+		// Then 
+		Set<String> expectedSet = new Set<String> {'Id', 'Name', 'UniqueIdentifier__c', 'Description__c'};
+		system.assertEquals(expectedSet, result, 'A specific field set is expected');
 	}
 }

--- a/force-app/main/default/classes/ReachedAchievementSelector.cls
+++ b/force-app/main/default/classes/ReachedAchievementSelector.cls
@@ -1,18 +1,14 @@
-public with sharing class ReachedAchievementSelector {
-	private static final String FIELDS_LIST = 'Id';
-
-	public static Map<Id, AggregateResult> getGroupedScoreAndCountByUser(Set<Id> ids) {
-		Map<Id, AggregateResult> result = new Map<Id, AggregateResult>();
-		if (ids.isEmpty()) {
-			return result;
-		}
-
-		Map<String, Object> binds = new Map<String, Object> { 'ids' => ids };
-		List<AggregateResult> aggregateResults = Database.queryWithBinds('SELECT User__c, SUM(Score__c)score, COUNT(Id)cnt FROM ReachedAchievement__c WHERE User__c IN :ids GROUP BY User__c ', binds, System.AccessLevel.SYSTEM_MODE);
-		for (AggregateResult aggregateResult : aggregateResults) {
-			result.put((Id) aggregateResult.get('User__c'), aggregateResult);
-		}
+public with sharing class ReachedAchievementSelector extends BaseSelector {
 	
-		return result;
+	public static ReachedAchievementSelector getInstance() {
+		return new ReachedAchievementSelector();
+	}
+
+	public override String sObjectApiName() {
+		return 'ReachedAchievement__c';
+	}
+
+	public override Set<String> fieldApiNames() {
+		return new Set<String> {'Id', 'Key__c', 'User__c', 'Achievement__c', 'Score__c'};
 	}
 }

--- a/force-app/main/default/classes/ReachedAchievementSelectorTest.cls
+++ b/force-app/main/default/classes/ReachedAchievementSelectorTest.cls
@@ -1,60 +1,31 @@
-@IsTest
+@IsTest(isParallel=true)
 private class ReachedAchievementSelectorTest {
 	@IsTest
-	private static void getGroupedScoreAndCountByUser_usersPasses_groupedValuesReturned(){
+	private static void sObjectApiName_sObjectNameReturned_nameIsValidated() {
 		// Given
-		Id profileId = UserInfo.getProfileId();
-		User user1 = TestDataFactory.createUser(profileId, 'FirstUser');
-		User user2 = TestDataFactory.createUser(profileId, 'SecondUser');
-		Measurement__c measurement = TestDataFactory.createMeasurement('Measurement');
-		Achievement__c achievement1 = TestDataFactory.createAchievement('Achievement1', measurement.Id);
-		Achievement__c achievement2 = TestDataFactory.createAchievement('Achievement2', measurement.Id);
-		Achievement__c achievement3 = TestDataFactory.createAchievement('Achievement3', measurement.Id);
-		ReachedAchievement__c reachedAchievement1 = TestDataFactory.createReachedAchievement(user1.Id, achievement1.Id);
-		ReachedAchievement__c reachedAchievement2 = TestDataFactory.createReachedAchievement(user1.Id, achievement2.Id);
-		ReachedAchievement__c reachedAchievement3 = TestDataFactory.createReachedAchievement(user1.Id, achievement3.Id);
-		ReachedAchievement__c reachedAchievement4 = TestDataFactory.createReachedAchievement(user2.Id, achievement1.Id);
-		Set<Id> userIds = new Set<Id>{ user1.Id, user2.Id };
-
+		ReachedAchievementSelector selector = ReachedAchievementSelector.getInstance();
+		
 		// When
 		Test.startTest();
-		Map<Id, AggregateResult> result = ReachedAchievementSelector.getGroupedScoreAndCountByUser(userIds);
+		String result = selector.sObjectApiName();
 		Test.stopTest();
 
-		// Then
-		System.assert(result.containsKey(user1.Id), 'AggregateResult is expected to exist in map');
-		System.assertEquals(3, (Decimal) result.get(user1.Id).get('cnt'), 'Total count of reached achievements is expected to be 3');
-		System.assertEquals(achievement1.Score__c + achievement2.Score__c + achievement3.Score__c, (Decimal) result.get(user1.Id).get('score'), 'Score should match the total of reached scores for the user');
-		System.assert(result.containsKey(user2.Id), 'AggregateResult is expected to exist in map');
-		System.assertEquals(1, (Decimal) result.get(user2.Id).get('cnt'), 'Total count of reached achievements is expected to be 3');
-		System.assertEquals(achievement1.Score__c, (Decimal) result.get(user2.Id).get('score'), 'Score should match the total of reached scores for the user');
+		// Then 
+		system.assertEquals('ReachedAchievement__c', result, 'ReachedAchievement__c sObject ApiName is expected');
 	}
 
 	@IsTest
-	private static void getGroupedScoreAndCountByUser_emptyList_emptyMapReturned(){
+	private static void fieldApiNames_sObjectNameReturned_fieldSetIsValidated() {
 		// Given
-		Set<Id> userIds = new Set<Id>();
-
+		ReachedAchievementSelector selector = ReachedAchievementSelector.getInstance();
+		
 		// When
 		Test.startTest();
-		Map<Id, AggregateResult> result = ReachedAchievementSelector.getGroupedScoreAndCountByUser(userIds);
+		Set<String> result = selector.fieldApiNames();
 		Test.stopTest();
 
-		// Then
-		System.assert(result.isEmpty(), 'Map is expected to be empty');
-	}
-
-	@IsTest
-	private static void getGroupedScoreAndCountByUser_userWithNoAchievements_emptyMapReturned(){
-		// Given
-		Set<Id> userIds = new Set<Id>{UserInfo.getUserId()};
-
-		// When
-		Test.startTest();
-		Map<Id, AggregateResult> result = ReachedAchievementSelector.getGroupedScoreAndCountByUser(userIds);
-		Test.stopTest();
-
-		// Then
-		System.assert(result.isEmpty(), 'Map is expected to be empty');
+		// Then 
+		Set<String> expectedSet = new Set<String> {'Id', 'Key__c', 'User__c', 'Achievement__c', 'Score__c'};
+		system.assertEquals(expectedSet, result, 'A specific field set is expected');
 	}
 }

--- a/force-app/main/default/classes/UniqueKeyFormatter.cls
+++ b/force-app/main/default/classes/UniqueKeyFormatter.cls
@@ -1,0 +1,5 @@
+public with sharing class UniqueKeyFormatter {
+	public static String generateUniqueKey(Id userId, Id entityId) {
+		return userId + '-' + entityId;
+	}
+}

--- a/force-app/main/default/classes/UniqueKeyFormatter.cls-meta.xml
+++ b/force-app/main/default/classes/UniqueKeyFormatter.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>57.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/UniqueKeyFormatterTest.cls
+++ b/force-app/main/default/classes/UniqueKeyFormatterTest.cls
@@ -1,0 +1,17 @@
+@IsTest(isParallel=true)
+private class UniqueKeyFormatterTest {
+	@IsTest
+	private static void generateUniqueKey_idsPassed_keyGenerated(){
+		// Given
+		Id userId = UserInfo.getUserId();
+		Measurement__c measurement = TestDataFactory.createMeasurement('Measurement');
+
+		// When
+		Test.startTest();
+		String result = UniqueKeyFormatter.generateUniqueKey(userId, measurement.Id);
+		Test.stopTest();
+
+		// Then
+		System.assertEquals(userId + '-' + measurement.Id, result, 'Key is expected to match the format');
+	}
+}

--- a/force-app/main/default/classes/UniqueKeyFormatterTest.cls-meta.xml
+++ b/force-app/main/default/classes/UniqueKeyFormatterTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>57.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/UserMeasurementIncrementTriggerHandler.cls
+++ b/force-app/main/default/classes/UserMeasurementIncrementTriggerHandler.cls
@@ -14,16 +14,20 @@ public with sharing class UserMeasurementIncrementTriggerHandler {
 	private void initExistingSObjectMaps(List<UserMeasurementIncrement__e> events) {
 		Set<Id> userIdsFromEvents = new Set<Id>();
 		Set<Id> measurementIdsFromEvents = new Set<Id>();
-		Map<Id, Id> measurementIdsByUserIdsMap = new Map<Id, Id>();
+		Set<String> userMeasurementKeys = new Set<String>();
 		for (UserMeasurementIncrement__e event : events) {
 			userIdsFromEvents.add(event.UserId__c);
 			measurementIdsFromEvents.add(event.MeasurementId__c);
-			measurementIdsByUserIdsMap.put(event.UserId__c, event.MeasurementId__c);
+			userMeasurementKeys.add(UniqueKeyFormatter.generateUniqueKey(event.UserId__c, event.MeasurementId__c));
 		}
 
-		existingUsersMap = new Map<Id, User> (UserSelector.getByIds(userIdsFromEvents));
-		existingMeasurementsMap = new Map<Id, Measurement__c> (MeasurementSelector.getByIds(measurementIdsFromEvents));
-		existingUserMeasurementsMap = UserMeasurementSelector.getByKeys(measurementIdsByUserIdsMap);
+		existingUsersMap = new Map<Id, User> ((List<User>) UserSelector.getInstance().getByIds(userIdsFromEvents));
+		existingMeasurementsMap = new Map<Id, Measurement__c> ((List<Measurement__c>) MeasurementSelector.getInstance().getByIds(measurementIdsFromEvents));
+		
+		List<UserMeasurement__c> userMeasurements = (List<UserMeasurement__c>) UserMeasurementSelector.getInstance().getByFieldValue('Key__c', 'IN', userMeasurementKeys);
+		for (UserMeasurement__c userMeasurement : userMeasurements) {
+			existingUserMeasurementsMap.put(userMeasurement.Key__c, userMeasurement);
+		}
 	}
 
 	public void processEvents() {
@@ -33,7 +37,7 @@ public with sharing class UserMeasurementIncrementTriggerHandler {
 					continue;
 				}
 
-				String upsertMapKey = event.UserId__c + '-' + event.MeasurementId__c;
+				String upsertMapKey = UniqueKeyFormatter.generateUniqueKey(event.UserId__c, event.MeasurementId__c);
 				if (measurementsToUpsert.containsKey(upsertMapKey)) {
 					measurementsToUpsert.get(upsertMapKey).Value__c += event.Increment__c;
 				} else if (existingUserMeasurementsMap.containsKey(upsertMapKey)) {

--- a/force-app/main/default/classes/UserMeasurementSelector.cls
+++ b/force-app/main/default/classes/UserMeasurementSelector.cls
@@ -1,30 +1,14 @@
-public with sharing class UserMeasurementSelector {
-	private static final String FIELDS_LIST = 'Id, Name, Key__c, Measurement__c, User__c, Value__c';
+public with sharing class UserMeasurementSelector extends BaseSelector {
 
-	public static Map<String, UserMeasurement__c> getByKeys(Map<Id, Id> measurementIdsByUserIdsMap) {
-		Map<String, UserMeasurement__c> result = new Map<String, UserMeasurement__c>();
+	public static UserMeasurementSelector getInstance() {
+		return new UserMeasurementSelector();
+	}
 
-		if (measurementIdsByUserIdsMap == null || measurementIdsByUserIdsMap.isEmpty()) {
-			return result;
-		}
+	public override String sObjectApiName() {
+		return 'UserMeasurement__c';
+	}
 
-		Set<String> keys = new Set<String>();
-		for (Id userId : measurementIdsByUserIdsMap.keySet()) {
-			Id measurementId = measurementIdsByUserIdsMap.get(userId);
-
-			keys.add(userId + '-' + measurementId);
-		}
-
-		Map<String, Object> binds = new Map<String, Object> { 'keys' => keys };
-		List<UserMeasurement__c> stats = Database.queryWithBinds('SELECT ' + FIELDS_LIST + ' FROM UserMeasurement__c WHERE Key__c IN :keys', binds, System.AccessLevel.SYSTEM_MODE);
-		if (stats == null || stats.isEmpty()) {
-			return result;
-		}
-
-		for (UserMeasurement__c stat : stats) {
-			result.put(stat.Key__c, stat);
-		}
-
-		return result;
+	public override Set<String> fieldApiNames() {
+		return new Set<String> {'Id', 'Name', 'Key__c', 'Measurement__c', 'User__c', 'Value__c'};
 	}
 }

--- a/force-app/main/default/classes/UserMeasurementSelectorTest.cls
+++ b/force-app/main/default/classes/UserMeasurementSelectorTest.cls
@@ -1,60 +1,32 @@
-@IsTest
+@IsTest(isParallel=true)
 private class UserMeasurementSelectorTest {
 	
 	@IsTest
-	private static void getByKey_recordWithKeyExists_recordsReturned(){
+	private static void sObjectApiName_sObjectNameReturned_nameIsValidated() {
 		// Given
-		Id profileId = UserInfo.getProfileId();
-
-		User user1 = TestDataFactory.createUser(profileId, 'user1');
-		User user2 = TestDataFactory.createUser(profileId, 'user2');
-		Measurement__c measurement = TestDataFactory.createMeasurement('measurement');
-
-		UserMeasurement__c userMeasurement1 = TestDataFactory.createUserMeasurement(user1.Id, measurement.Id, 1);
-		UserMeasurement__c userMeasurement2 = TestDataFactory.createUserMeasurement(user2.Id, measurement.Id, 1);
-
-		Map<Id, Id> measurementIdByUserIdMap = new Map<Id, Id> { user1.Id => measurement.Id };
-
-		// When 
+		UserMeasurementSelector selector = UserMeasurementSelector.getInstance();
+		
+		// When
 		Test.startTest();
-		Map<String, UserMeasurement__c> result = UserMeasurementSelector.getByKeys(measurementIdByUserIdMap);
+		String result = selector.sObjectApiName();
 		Test.stopTest();
 
-		// Then
-		System.assertEquals(1, result.size(), 'Record is expected to be found');
-		System.assert(result.containsKey(user1.Id + '-' + measurement.Id), 'Map is expected to have a specific user userMeasurement');
-		System.assertEquals(userMeasurement1.Id, result.get(user1.Id + '-' + measurement.Id).Id, 'Map is expected to have a specific user userMeasurement');
-		System.assert(!result.containsKey(user2.Id + '-' + measurement.Id), 'Map is not expected to have a specific user userMeasurement');
+		// Then 
+		system.assertEquals('UserMeasurement__c', result, 'UserMeasurement__c sObject ApiName is expected');
 	}
 
 	@IsTest
-	private static void getByKey_mapIsEmpty_emptyResult(){
+	private static void fieldApiNames_sObjectNameReturned_fieldSetIsValidated() {
 		// Given
-		Measurement__c measurement = TestDataFactory.createMeasurement('measurement');
-		Map<Id, Id> measurementIdByUserIdMap = new Map<Id, Id> {UserInfo.getUserId() => measurement.Id};
-
-		// When 
+		UserMeasurementSelector selector = UserMeasurementSelector.getInstance();
+		
+		// When
 		Test.startTest();
-		Map<String, UserMeasurement__c> result = UserMeasurementSelector.getByKeys(measurementIdByUserIdMap);
+		Set<String> result = selector.fieldApiNames();
 		Test.stopTest();
 
-		// Then
-		System.assertNotEquals(null, result, 'Empty map is expected to be returned');
-		System.assertEquals(0, result.size(), 'Empty map is expected to be returned');
-	}
-
-	@IsTest
-	private static void getByKey_userStatDoesntExist_emptyResult(){
-		// Given
-		Map<Id, Id> measurementIdByUserIdMap = new Map<Id, Id>();
-
-		// When 
-		Test.startTest();
-		Map<String, UserMeasurement__c> result = UserMeasurementSelector.getByKeys(measurementIdByUserIdMap);
-		Test.stopTest();
-
-		// Then
-		System.assertNotEquals(null, result, 'Empty map is expected to be returned');
-		System.assertEquals(0, result.size(), 'Empty map is expected to be returned');
+		// Then 
+		Set<String> expectedSet = new Set<String> {'Id', 'Name', 'Key__c', 'Measurement__c', 'User__c', 'Value__c'};
+		system.assertEquals(expectedSet, result, 'A specific field set is expected');
 	}
 }

--- a/force-app/main/default/classes/UserRatingsHelper.cls
+++ b/force-app/main/default/classes/UserRatingsHelper.cls
@@ -1,0 +1,16 @@
+public with sharing class UserRatingsHelper {
+    public static Map<Id, AggregateResult> getTotalScoreAndCountByUser(Set<Id> ids) {
+		Map<Id, AggregateResult> result = new Map<Id, AggregateResult>();
+		if (ids.isEmpty()) {
+			return result;
+		}
+
+		Map<String, Object> binds = new Map<String, Object> { 'ids' => ids };
+		List<AggregateResult> aggregateResults = Database.queryWithBinds('SELECT User__c, SUM(Score__c)score, COUNT(Id)cnt FROM ReachedAchievement__c WHERE User__c IN :ids GROUP BY User__c ', binds, System.AccessLevel.SYSTEM_MODE);
+		for (AggregateResult aggregateResult : aggregateResults) {
+			result.put((Id) aggregateResult.get('User__c'), aggregateResult);
+		}
+	
+		return result;
+	}
+}

--- a/force-app/main/default/classes/UserRatingsHelper.cls-meta.xml
+++ b/force-app/main/default/classes/UserRatingsHelper.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>57.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/UserRatingsHelperTest.cls
+++ b/force-app/main/default/classes/UserRatingsHelperTest.cls
@@ -1,0 +1,60 @@
+@IsTest
+private class UserRatingsHelperTest {
+	@IsTest
+	private static void getTotalScoreAndCountByUser_usersPasses_groupedValuesReturned(){
+		// Given
+		Id profileId = UserInfo.getProfileId();
+		User user1 = TestDataFactory.createUser(profileId, 'FirstUser');
+		User user2 = TestDataFactory.createUser(profileId, 'SecondUser');
+		Measurement__c measurement = TestDataFactory.createMeasurement('Measurement');
+		Achievement__c achievement1 = TestDataFactory.createAchievement('Achievement1', measurement.Id);
+		Achievement__c achievement2 = TestDataFactory.createAchievement('Achievement2', measurement.Id);
+		Achievement__c achievement3 = TestDataFactory.createAchievement('Achievement3', measurement.Id);
+		ReachedAchievement__c reachedAchievement1 = TestDataFactory.createReachedAchievement(user1.Id, achievement1.Id);
+		ReachedAchievement__c reachedAchievement2 = TestDataFactory.createReachedAchievement(user1.Id, achievement2.Id);
+		ReachedAchievement__c reachedAchievement3 = TestDataFactory.createReachedAchievement(user1.Id, achievement3.Id);
+		ReachedAchievement__c reachedAchievement4 = TestDataFactory.createReachedAchievement(user2.Id, achievement1.Id);
+		Set<Id> userIds = new Set<Id>{ user1.Id, user2.Id };
+
+		// When
+		Test.startTest();
+		Map<Id, AggregateResult> result = UserRatingsHelper.getTotalScoreAndCountByUser(userIds);
+		Test.stopTest();
+
+		// Then
+		System.assert(result.containsKey(user1.Id), 'AggregateResult is expected to exist in map');
+		System.assertEquals(3, (Decimal) result.get(user1.Id).get('cnt'), 'Total count of reached achievements is expected to be 3');
+		System.assertEquals(achievement1.Score__c + achievement2.Score__c + achievement3.Score__c, (Decimal) result.get(user1.Id).get('score'), 'Score should match the total of reached scores for the user');
+		System.assert(result.containsKey(user2.Id), 'AggregateResult is expected to exist in map');
+		System.assertEquals(1, (Decimal) result.get(user2.Id).get('cnt'), 'Total count of reached achievements is expected to be 3');
+		System.assertEquals(achievement1.Score__c, (Decimal) result.get(user2.Id).get('score'), 'Score should match the total of reached scores for the user');
+	}
+
+	@IsTest
+	private static void getTotalScoreAndCountByUser_emptyList_emptyMapReturned(){
+		// Given
+		Set<Id> userIds = new Set<Id>();
+
+		// When
+		Test.startTest();
+		Map<Id, AggregateResult> result = UserRatingsHelper.getTotalScoreAndCountByUser(userIds);
+		Test.stopTest();
+
+		// Then
+		System.assert(result.isEmpty(), 'Map is expected to be empty');
+	}
+
+	@IsTest
+	private static void getTotalScoreAndCountByUser_userWithNoAchievements_emptyMapReturned(){
+		// Given
+		Set<Id> userIds = new Set<Id>{UserInfo.getUserId()};
+
+		// When
+		Test.startTest();
+		Map<Id, AggregateResult> result = UserRatingsHelper.getTotalScoreAndCountByUser(userIds);
+		Test.stopTest();
+
+		// Then
+		System.assert(result.isEmpty(), 'Map is expected to be empty');
+	}
+}

--- a/force-app/main/default/classes/UserRatingsHelperTest.cls-meta.xml
+++ b/force-app/main/default/classes/UserRatingsHelperTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>57.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/UserSelector.cls
+++ b/force-app/main/default/classes/UserSelector.cls
@@ -1,12 +1,14 @@
-public with sharing class UserSelector {
-	private static final String FIELDS_LIST = 'Id, FullPhotoUrl, Name';
+public with sharing class UserSelector extends BaseSelector {
+	
+	public static UserSelector getInstance() {
+		return new UserSelector();
+	}
 
-	public static List<User> getByIds(Set<Id> ids) {
-		if (ids.isEmpty()) {
-			return new List<User>();
-		}
+	public override String sObjectApiName() {
+		return 'User';
+	}
 
-		Map<String, Object> binds = new Map<String, Object> { 'ids' => ids };
-		return Database.queryWithBinds('SELECT ' + FIELDS_LIST + ' FROM User WHERE Id IN :ids', binds, System.AccessLevel.SYSTEM_MODE);
+	public override Set<String> fieldApiNames() {
+		return new Set<String> {'Id', 'FullPhotoUrl', 'Name'};
 	}
 }

--- a/force-app/main/default/classes/UserSelectorTest.cls
+++ b/force-app/main/default/classes/UserSelectorTest.cls
@@ -1,5 +1,34 @@
 @IsTest
 public with sharing class UserSelectorTest {
+
+	@IsTest
+	private static void sObjectApiName_sObjectNameReturned_nameIsValidated() {
+		// Given
+		UserSelector selector = UserSelector.getInstance();
+		
+		// When
+		Test.startTest();
+		String result = selector.sObjectApiName();
+		Test.stopTest();
+
+		// Then 
+		system.assertEquals('User', result, 'User sObject ApiName is expected');
+	}
+
+	@IsTest
+	private static void fieldApiNames_sObjectNameReturned_fieldSetIsValidated() {
+		// Given
+		UserSelector selector = UserSelector.getInstance();
+		
+		// When
+		Test.startTest();
+		Set<String> result = selector.fieldApiNames();
+		Test.stopTest();
+
+		// Then 
+		Set<String> expectedSet = new Set<String> {'Id', 'FullPhotoUrl', 'Name'};
+		system.assertEquals(expectedSet, result, 'A specific field set is expected');
+	}
 	
 	@IsTest
 	private static void getByIds_recordWithIdExists_recordsReturned(){
@@ -10,7 +39,7 @@ public with sharing class UserSelectorTest {
 
 		// When 
 		Test.startTest();
-		List<User> result = UserSelector.getByIds(new Set<Id>{ user1.Id });
+		List<User> result = UserSelector.getInstance().getByIds(new Set<Id>{ user1.Id });
 		Map<Id, User> resultMap = new Map<Id, User>(result);
 		Test.stopTest();
 
@@ -21,13 +50,32 @@ public with sharing class UserSelectorTest {
 	}
 
 	@IsTest
+	private static void getAll_recordsExists_recordsReturned(){
+		// Given
+		Id profileId = UserInfo.getProfileId();
+		User user1 = TestDataFactory.createUser(profileId, 'user1');
+		User user2 = TestDataFactory.createUser(profileId, 'user2');
+
+		// When 
+		Test.startTest();
+		List<User> result = UserSelector.getInstance().getAll();
+		Map<Id, User> resultMap = new Map<Id, User>(result);
+		Test.stopTest();
+
+		List<User> users = [SELECT Id FROM USER];
+
+		// Then
+		System.assertEquals(users.size(), result.size(), 'All records are expected to be returned by selector');
+	}
+
+	@IsTest
 	private static void getByIds_emptyIdsSet_emptyListReturned(){
 		// Given
 		Set<Id> ids = new Set<Id>();
 
 		// When 
 		Test.startTest();
-		List<User> result = UserSelector.getByIds(ids);
+		List<User> result = UserSelector.getInstance().getByIds(ids);
 		Test.stopTest();
 
 		// Then


### PR DESCRIPTION
close #59 
Replacing selectors with weird implementations with BaseSelector class
Refactoring of the old code that was using "non-standard" selectors
Removing unnecessary unit tests