### PR TITLE
Issue-216: Fixing the ordering of the Achievements in the achievemetList

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,23 +1,25 @@
 # ScoreHub Release Notes
 
 ## version 2.0.0.WIP
+### version 2.0.0.4
+- The Achievements list on the Leaderboard page and the Comparison UI were adjusted to group Achievements by their related Measurement and order by Name. This improvement makes it easier for ScoreHub Admins to organize achievements in the list and makes the list more user-friendly.
+
 ### version 2.0.0.3
-- Adjusting "Recently Viewed" list views for Achievements and Measurements to have the same set of fields as "All Measurements" and "All Achievements" views
+- Adjusting "Recently Viewed" list views for Achievements and Measurements to have the same set of fields as "All Measurements" and "All Achievements" views.
 
 ### version 2.0.0.2
-- Unsubscribing from `AchievementReached__e` platform event during `unrender` of ScoreHubUtility component
+- Unsubscribing from `AchievementReached__e` platform event during `unrender` of the ScoreHubUtility component.
 
 ### version 2.0.0.1
-- Optimizing SOQL queries 
-- Refactoring Unit tests to migrate from System.Assert to Assert class
+- Optimizing SOQL queries. 
+- Refactoring Unit tests to migrate from System.Assert to Assert class.
 
 ## version 1.0.0.1
-First release version of ScoreHub app
-Main functionality included in the release:
-- ScoreHub permission sets and permission set groups
-- ScoreHub custom sObjects to store data about Measurements and Achievements
-- ScoreHub platform events for reached achievement and measurement changes
-- ScoreHub App and related LWC components
-- ScoreHub utility bar component for custom notifications
+First release version of ScoreHub app. Main functionality included in the release:
+- ScoreHub permission sets and permission set groups.
+- ScoreHub custom sObjects to store data about Measurements and Achievements.
+- ScoreHub platform events for reached achievement and measurement changes.
+- ScoreHub App and related LWC components.
+- ScoreHub utility bar component for custom notifications.
 
 More detailed information can be found in the [article](https://www.linkedin.com/pulse/gameforce-part-7-mvp-fedir-kryvyi-sqkyf/?trackingId=dKd2vpClQCGbSjQrzyrKcA%3D%3D)

--- a/force-app/main/default/classes/AchievementsDataHelper.cls
+++ b/force-app/main/default/classes/AchievementsDataHelper.cls
@@ -63,6 +63,8 @@ public with sharing class AchievementsDataHelper {
 		achievementWrapper.score = achievement.Score__c;
 		achievementWrapper.isReached = false;
 		achievementWrapper.ReachedDate = 0;
+		achievementWrapper.measurementId = achievement.Measurement__c;
+		achievementWrapper.name = achievement.Name;
 		return achievementWrapper;
 	}
 

--- a/force-app/main/default/classes/AchievementsDataHelperTest.cls
+++ b/force-app/main/default/classes/AchievementsDataHelperTest.cls
@@ -134,6 +134,8 @@ private class AchievementsDataHelperTest {
 
 		// Then
 		Assert.areEqual(achievement1.Id, cardData.Id);
+		Assert.areEqual(achievement1.Name, cardData.name);
+		Assert.areEqual(achievement1.Measurement__c, cardData.measurementId);
 		Assert.areEqual(achievement1.UITitle__c, cardData.uiTitle);
 		Assert.areEqual(achievement1.UIDescription__c, cardData.uiDescription);
 		Assert.areEqual(achievement1.Score__c, cardData.score);
@@ -154,6 +156,8 @@ private class AchievementsDataHelperTest {
 
 		// Then
 		Assert.areEqual(achievement1.Id, cardData.Id);
+		Assert.areEqual(achievement1.Name, cardData.name);
+		Assert.areEqual(achievement1.Measurement__c, cardData.measurementId);
 		Assert.areEqual(achievement1.UITitle__c, cardData.uiTitle);
 		Assert.areEqual(achievement1.UIDescription__c, cardData.uiDescription);
 		Assert.areEqual(achievement1.Score__c, cardData.score);

--- a/force-app/main/default/classes/DataWrappers.cls
+++ b/force-app/main/default/classes/DataWrappers.cls
@@ -28,5 +28,9 @@ public with sharing class DataWrappers {
 		public Boolean isReached { get; set; }
 		@AuraEnabled
 		public Long reachedDate { get; set; }
+		@AuraEnabled
+		public Id measurementId { get; set; }
+		@AuraEnabled
+		public String name { get; set; }
 	}
 }

--- a/force-app/main/default/lwc/achievementsList/achievementsList.html
+++ b/force-app/main/default/lwc/achievementsList/achievementsList.html
@@ -1,7 +1,7 @@
 <template>
   <template lwc:if={achievements}>
     <div class="slds-card">
-      <template for:each={achievements} for:item="achievement">
+      <template for:each={orderedList} for:item="achievement">
         <c-achievement-list-item key={achievement.id} achievement={achievement}></c-achievement-list-item>
       </template>
     </div>

--- a/force-app/main/default/lwc/achievementsList/achievementsList.js
+++ b/force-app/main/default/lwc/achievementsList/achievementsList.js
@@ -8,4 +8,17 @@ export default class AchievementsList extends LightningElement {
     };
 
     @api achievements
+
+    get orderedList() {
+        let unorderedList = [... this.achievements]
+        unorderedList.sort((a, b) => {
+            if (a.measurementId.localeCompare(b.measurementId) === 0) {
+                return a.name.localeCompare(b.name);
+            } else {
+                return a.measurementId.localeCompare(b.measurementId);
+            }
+        });
+
+        return unorderedList
+    }
 }


### PR DESCRIPTION
Adding sorting logic to achievementsList component:
- Grouping achievements together by measurement__c
- Ordering by "Name" field to make it easier for ScoreHub Admins to order Achievements by their importance to end user