### PR TITLE
Issue-218: Fixing the ratio of user avatar in Leaderboard page

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -2,6 +2,9 @@
 
 ## version 2.0.0.WIP
 ### version 2.0.0.4
+- Improving the User Card component to ensure that avatars with aspect ratios different from 1:1 are correctly displayed.
+
+### version 2.0.0.4
 - The Achievements list on the Leaderboard page and the Comparison UI were adjusted to group Achievements by their related Measurement and order by Name. This improvement makes it easier for ScoreHub Admins to organize achievements in the list and makes the list more user-friendly.
 
 ### version 2.0.0.3

--- a/force-app/main/default/classes/DataWrappers.cls
+++ b/force-app/main/default/classes/DataWrappers.cls
@@ -6,7 +6,7 @@ public with sharing class DataWrappers {
 		@AuraEnabled
 		public String name { get; set; }
 		@AuraEnabled
-		public String fullPhotoUrl { get; set; }
+		public String smallPhotoUrl { get; set; }
 		@AuraEnabled
 		public Decimal reachedAchievementsCount { get; set; }
 		@AuraEnabled

--- a/force-app/main/default/classes/UserDataHelper.cls
+++ b/force-app/main/default/classes/UserDataHelper.cls
@@ -14,7 +14,7 @@ public with sharing class UserDataHelper {
 		DataWrappers.UserCardData userCardData = new DataWrappers.UserCardData();
 		userCardData.Id = user.Id;
 		userCardData.name = user.Name;
-		userCardData.fullPhotoUrl = user.FullPhotoUrl;
+		userCardData.smallPhotoUrl = user.SmallPhotoUrl;
 		userCardData.totalAchievementsCount = allAchievementsCount;
 		userCardData.totalScore = userAgResult != null ? (Decimal) userAgResult.get('score') : 0;
 		userCardData.reachedAchievementsCount = userAgResult != null ? (Decimal) userAgResult.get('cnt') : 0;

--- a/force-app/main/default/classes/UserInfoControllerTest.cls
+++ b/force-app/main/default/classes/UserInfoControllerTest.cls
@@ -3,7 +3,7 @@ private class UserInfoControllerTest {
 	@IsTest
 	private static void getUserInfoById_userWithReachedAchivementsExists_infoReturned() {
 		// Given
-		User usr = [SELECT Id, Name, FullPhotoUrl FROM User WHERE ID = :UserInfo.getUserId() LIMIT 1];
+		User usr = [SELECT Id, Name, SmallPhotoUrl FROM User WHERE ID = :UserInfo.getUserId() LIMIT 1];
 		Measurement__c measurement = TestDataFactory.createMeasurement('Measurement');
 		Achievement__c achievement1 = TestDataFactory.createAchievement('Ach1', measurement.Id);
 		Achievement__c achievement2 = TestDataFactory.createAchievement('Ach2', measurement.Id);
@@ -23,7 +23,7 @@ private class UserInfoControllerTest {
 		Assert.isNotNull(cardDataMap, 'Map with userInfo is expected to be returned');
 		DataWrappers.UserCardData cardData = cardDataMap.get(usr.Id);
 		Assert.areEqual(usr.Name, cardData.name, 'Name of current user is expected to be returned');
-		Assert.areEqual(usr.FullPhotoUrl, cardData.fullPhotoUrl, 'FullPhotoUrl of current user is expected to be returned');
+		Assert.areEqual(usr.SmallPhotoUrl, cardData.smallPhotoUrl, 'SmallPhotoUrl of current user is expected to be returned');
 		Assert.areEqual(2, cardData.reachedAchievementsCount, 'Total number of reached achievements is expected');
 		Assert.areEqual(2, cardData.totalAchievementsCount, 'Total number of achievements is expected');
 		Assert.areEqual(achievement1.Score__c + achievement2.Score__c, cardData.totalScore, 'Total score of all reached achievements is expected');
@@ -33,7 +33,7 @@ private class UserInfoControllerTest {
 	private static void getUserInfoById_UnexpectedException_ExceptionHandled() {
 		// Given
 		UserInfoController.throwException = true;
-		User usr = [SELECT Id, Name, FullPhotoUrl FROM User WHERE ID = :UserInfo.getUserId() LIMIT 1];
+		User usr = [SELECT Id, Name, SmallPhotoUrl FROM User WHERE ID = :UserInfo.getUserId() LIMIT 1];
 		
 		// When
 		Test.startTest();

--- a/force-app/main/default/classes/UserSelector.cls
+++ b/force-app/main/default/classes/UserSelector.cls
@@ -9,6 +9,6 @@ public with sharing class UserSelector extends BaseSelector {
 	}
 
 	public override Set<String> fieldApiNames() {
-		return new Set<String> {'Id', 'FullPhotoUrl', 'Name'};
+		return new Set<String> {'Id', 'SmallPhotoUrl', 'Name'};
 	}
 }

--- a/force-app/main/default/classes/UserSelectorTest.cls
+++ b/force-app/main/default/classes/UserSelectorTest.cls
@@ -26,7 +26,7 @@ public with sharing class UserSelectorTest {
 		Test.stopTest();
 
 		// Then 
-		Set<String> expectedSet = new Set<String> {'Id', 'FullPhotoUrl', 'Name'};
+		Set<String> expectedSet = new Set<String> {'Id', 'SmallPhotoUrl', 'Name'};
 		Assert.areEqual(expectedSet, result, 'A specific field set is expected');
 	}
 	

--- a/force-app/main/default/lwc/userCard/userCard.html
+++ b/force-app/main/default/lwc/userCard/userCard.html
@@ -4,7 +4,7 @@
       <template lwc:if={userInfo}>
         <div class="slds-col slds-grow-none">
           <lightning-avatar variant="circle" fallback-icon-name="standard:avatar_loading" size="large"
-            src={userInfo.fullPhotoUrl} alternative-text={labels.AvatarAltTextLabel}></lightning-avatar>
+            src={userInfo.smallPhotoUrl} alternative-text={labels.AvatarAltTextLabel}></lightning-avatar>
         </div>
         <div class="slds-col slds-var-p-horizontal_small slds-truncate slds-grid_align-end">
           <!-- Name -->


### PR DESCRIPTION
Replacing FullPhotoUrl with SmallPhotoUrl which is used for avatars in the system